### PR TITLE
Fix test container generation for Fedora

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { dockerfile: 'Dockerfile-CentOS-9-Stream',   tag: 'centos:stream9' }
+                    - { dockerfile: 'Dockerfile-Fedora-latest',     tag: 'fedora:latest' }
         steps:
             -   name: Check out the repo
                 uses: actions/checkout@v2


### PR DESCRIPTION
<description/>

Reenable Fedora test container generation. Or was it intentional to test against Cent OS 9 Stream ?