### PR TITLE
feat(hwdb): add hwdb module to install hwdb.bin on demand

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -319,6 +319,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/91tpm2-tss
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fstab-sys
+%{dracutlibdir}/modules.d/95hwdb
 %{dracutlibdir}/modules.d/95lunmask
 %{dracutlibdir}/modules.d/95resume
 %{dracutlibdir}/modules.d/95rootfs-block

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -406,6 +406,10 @@ fstab-sys:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/95fstab-sys/*'
 
+hwdb:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/95hwdb/*'
+
 iscsi:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/95iscsi/*'

--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    return 255
+}
+
+# called by dracut
+install() {
+    local hwdb_bin
+
+    # Follow the same priority as `systemd-hwdb`; `/etc` is the default
+    # and `/usr/lib` an alternative location.
+    hwdb_bin="${udevconfdir}"/hwdb.bin
+
+    if [[ ! -r ${hwdb_bin} ]]; then
+        hwdb_bin="${udevdir}"/hwdb.bin
+    fi
+
+    if [[ $hostonly ]]; then
+        inst_multiple -H "${hwdb_bin}"
+    else
+        inst_multiple "${hwdb_bin}"
+    fi
+}


### PR DESCRIPTION
Module to install hwdb.bin. Further extensions might make only selected part of hwdb installable to save space. The module is not included by default.

Including the module adds 2MB of compressed data (on Fedora, the file has 12MB).

Installing hwdb.bin is needed in case of custom HW like a keyboard/mouse, or various interfaces.

Original PR: https://github.com/dracutdevs/dracut/pull/1681