### PR TITLE
Backport fips-crypto-policies module

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -8,7 +8,7 @@
 
 Name: dracut
 Version: 103
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 Summary: Initramfs generator using udev
 
@@ -251,6 +251,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/00warpclock
 %endif
 %{dracutlibdir}/modules.d/01fips
+%{dracutlibdir}/modules.d/01fips-crypto-policies
 %{dracutlibdir}/modules.d/01systemd-ac-power
 %{dracutlibdir}/modules.d/01systemd-ask-password
 %{dracutlibdir}/modules.d/01systemd-bsod
@@ -426,6 +427,10 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{_prefix}/lib/kernel/install.d/51-dracut-rescue.install
 
 %changelog
+* Thu Sep 19 2024 Clemens Lang <cllang@redhat.com> - 103-2
+- feat(fips-crypto-policies): make c-p follow FIPS mode automatically
+- fix(fips-crypto-policies): make it depend on fips dracut module
+
 * Mon Sep 16 2024 Pavel Valena <pvalena@redhat.com> - 103-1
 - Update to dracut 103.
 

--- a/modules.d/01fips-crypto-policies/fips-crypto-policies.sh
+++ b/modules.d/01fips-crypto-policies/fips-crypto-policies.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/sh
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ] || [ -z "$fipsmode" ]; then
+    # Do nothing if not in FIPS mode
+    return 0
+fi
+
+policyfile=/etc/crypto-policies/config
+fipspolicyfile=/usr/share/crypto-policies/default-fips-config
+backends=/etc/crypto-policies/back-ends
+fipsbackends=/usr/share/crypto-policies/back-ends/FIPS
+
+# When in FIPS mode, check the active crypto policy by reading the
+# $root/etc/crypto-policies/config file. If it is not "FIPS", or does not start
+# with "FIPS:", automatically switch to the FIPS policy by creating
+# bind-mounts.
+
+if ! [ -r "${NEWROOT}${policyfile}" ]; then
+    # No crypto-policies configured, possibly not a system that uses
+    # crypto-policies?
+    return 0
+fi
+
+if ! [ -f "${NEWROOT}${fipspolicyfile}" ]; then
+    # crypto-policies is too old to deal with automatic bind-mounting of the
+    # FIPS policy over the normal policy, do not attempt to do the bind-mount.
+    return 0
+fi
+
+policy=$(cat "${NEWROOT}${policyfile}")
+
+# Remove the largest suffix pattern matching ":*" from the string (i.e., the
+# complete list of active policy modules), then check for FIPS. This is part of
+# POSIX sh (https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02).
+if [ "${policy%%:*}" = "FIPS" ]; then
+    return 0
+fi
+
+# Current crypto policy is not FIPS or FIPS-based, but the system is in FIPS
+# mode; this is an inconsistent configuration. Automatically bind-mount a FIPS
+# configuration over this.
+if ! mount -o bind,ro "${NEWROOT}${fipsbackends}" "${NEWROOT}${backends}"; then
+    warn "Failed to bind-mount FIPS policy over ${backends} (the system is in FIPS mode, but the crypto-policy is not)."
+    # If this bind-mount failed, don't attempt to do the other one to avoid
+    # a system that seems to be in FIPS crypto-policy but actually is not.
+    return 0
+fi
+
+mount -o bind,ro "${NEWROOT}${fipspolicyfile}" "${NEWROOT}${policyfile}" \
+    || warn "Failed to bind-mount FIPS crypto-policy state file over ${policyfile} (the system is in FIPS mode, but the crypto-policy is not)."

--- a/modules.d/01fips-crypto-policies/module-setup.sh
+++ b/modules.d/01fips-crypto-policies/module-setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+# called by dracut
+check() {
+    # only enable on systems that use crypto-policies
+    [ -d "$dracutsysrootdir/etc/crypto-policies" ] && return 0
+
+    # include when something else depends on it or it is explicitly requested
+    return 255
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_hook pre-pivot 01 "$moddir/fips-crypto-policies.sh"
+
+    inst_multiple mount
+}

--- a/modules.d/01fips-crypto-policies/module-setup.sh
+++ b/modules.d/01fips-crypto-policies/module-setup.sh
@@ -11,6 +11,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo fips
     return 0
 }
 


### PR DESCRIPTION
Users that enable FIPS mode using `fips-mode-seutp --enable` and later disable it using `fips-mode-setup --disable` commonly notice that `fips-mode-setup --check` tells them that their system is in an inconsistent state. This is because (among other things) `fips-mode-setup --disable` does not undo adding the `fips` module to the initramfs out of an abundance of caution to avoid breaking a system's boot.

This situation is not great, because users are often confused by the `fips-mode-setup --check` message and will not stop using `fips-mode-setup --disable` (despite the manpage clearly saying that it's for testing purposes only and unsupported).

We plan on solving this issue once and for all in CentOS 10 Stream by eliminating the possibility of inconsistency. For this to work, we need a single source of truth that decides whether FIPS is enabled or not, and all other parts need to follow along automatically. The obvious choice for the single source of truth is the kernel command line, i.e. if it contains fips=1, FIPS should be enabled, if it doesn't or it contains fips=0, FIPS mode should be disabled.

This backport from upstream achieves a significant part of that, by automatically switching the crypto-policy to FIPS on systems booted with `fips=1` on the kernel command line. The crypto-policies package has been adjusted to detect and transparently deal with situation (especially during package updates) in F41 and rawhide with upstream commit [e7b94d2a309c5348aa534c5a1d9718261a2ec89a](https://src.fedoraproject.org/rpms/crypto-policies/c/e7b94d2a309c5348aa534c5a1d9718261a2ec89a?branch=rawhide).

Cherry picked from commits [bd3c1e1cc2f656f7ee4ff47e00ca716d52a86a3d](https://github.com/dracut-ng/dracut-ng/commit/bd3c1e1cc2f656f7ee4ff47e00ca716d52a86a3d) and [a2096dafdbfc88eed91ce34b1f4d27e7eb7ca839](https://github.com/dracut-ng/dracut-ng/commit/a2096dafdbfc88eed91ce34b1f4d27e7eb7ca839).

Related: CRYPTO-13556
