### PR TITLE
fix rescue

### DIFF
--- a/.distro/rebase.sh
+++ b/.distro/rebase.sh
@@ -178,7 +178,7 @@ shift
 [[ ${pv} -lt $v ]]
 
 : 'List files changed downstream'
-F="$((gitds ${v}-pre-rebase ${pv} | head -n -1; gitds ${v} | head -n -1) | tr -s ' ' | cut -d' ' -f2 | sort -u | xargs echo)"
+F="$( (gitds ${v}-pre-rebase ${pv} | head -n -1; gitds ${v} | head -n -1) | tr -s ' ' | cut -d' ' -f2 | sort -u | xargs echo)"
 
 
 : "Diff downstream changes"
@@ -191,6 +191,7 @@ gitds -p ${v}
 gitds -p ${v} > "dracut_rebase_${v}_changes_upstream_$(date -I).diff"
 
 wip
+
 
 : 'Upgrade files version'
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,6 @@ space_redirects    = true
 [man/*.xml]
 indent_style = space
 indent_size = 2
+
+[.distro/**]
+ignore = true

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -119,8 +119,8 @@ case "$COMMAND" in
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
             # shellcheck disable=SC2046
-            dracut -f \
-                --add-confdir rescue \
+            dracut -f --no-hostonly --no-uefi \
+                -a "rescue" \
                 $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
                 --kver "$KERNEL_VERSION" \
                 "$BOOT_DIR_ABS/$INITRD"


### PR DESCRIPTION
- **ci: shfmt workaround for zsh rebase tool**
- **revert: "fix(rescue): make rescue always no-hostonly"**
