### PR TITLE
ci: remove dmraid from Fedora

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -17,7 +17,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     device-mapper-multipath \
     dhcp-client \
     dhcp-server \
-    dmraid \
     e2fsprogs \
     erofs-utils \
     f2fs-tools \


### PR DESCRIPTION
it fails with "No match for argument: dmraid"
