### PR TITLE
Revert "feat(hwdb): add hwdb module to install hwdb.bin on demand"

### DIFF
--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -12,11 +12,12 @@ check() {
 
 # called by dracut
 install() {
-    # Follow the same priority as `systemd-hwdb`; `/etc` is the default
-    # and `/usr/lib` an alternative location.
-    inst_multiple "${udevconfdir}"/hwdb.bin
+    inst_multiple -o \
+        "${udevdir}"/hwdb.bin
 
+    # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
-        inst_multiple -H -o "${udevdir}"/hwdb.bin
+        inst_multiple -H -o \
+            "$udevconfdir"/hwdb.bin
     fi
 }


### PR DESCRIPTION
This reverts commit 7ff102c722877e78e222fae819fb1b3cddef8d25.

Ref: https://github.com/redhat-plumbers/dracut-fedora/issues/60

Fixes: https://github.com/redhat-plumbers/dracut-fedora/issues/60
