### PR TITLE
fix(hwdb): do not use /etc for non-hostonly

### DIFF
--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -12,11 +12,12 @@ check() {
 
 # called by dracut
 install() {
-    # Follow the same priority as `systemd-hwdb`; `/etc` is the default
-    # and `/usr/lib` an alternative location.
-    inst_multiple "${udevconfdir}"/hwdb.bin
+    inst_multiple -o \
+        "${udevdir}"/hwdb.bin
 
-    if [[ $hostonly ]]; then
-        inst_multiple -H -o "${udevdir}"/hwdb.bin
+    # Install the hosts local user configurations if enabled.
+    if [[ ${hostonly-} ]]; then
+        inst_multiple -H -o \
+            "$udevconfdir"/hwdb.bin
     fi
 }


### PR DESCRIPTION
Currently Fedora is reading /etc even for generic initrds. Fix it by matching upstream.

Fixes: https://github.com/redhat-plumbers/dracut-fedora/issues/60
