### PR TITLE
switch to upstream rescue images generation

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -216,13 +216,13 @@ mkdir -p $RPM_BUILD_ROOT/var/lib/dracut/overlay
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log
 touch $RPM_BUILD_ROOT%{_localstatedir}/log/dracut.log
 mkdir -p $RPM_BUILD_ROOT%{_sharedstatedir}/initramfs
-mkdir -p $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d
+mkdir -p $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/rescue
 
 install -m 0644 dracut.conf.d/fedora.conf.example $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/01-dist.conf
+install -m 0644 dracut.conf.d/rescue/10-rescue.conf $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/rescue/10-rescue.conf
 rm -f $RPM_BUILD_ROOT%{_mandir}/man?/*suse*
 
 echo 'hostonly="no"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/02-generic-image.conf
-echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/02-rescue.conf
 
 %files
 %if %{with doc}
@@ -450,7 +450,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/dracut.conf.d/02-generic-image.conf
 
 %files config-rescue
-%{dracutlibdir}/dracut.conf.d/02-rescue.conf
+%{dracutlibdir}/dracut.conf.d/rescue/10-rescue.conf
 %{_prefix}/lib/kernel/install.d/51-dracut-rescue.install
 
 %changelog

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -2,14 +2,26 @@
 
 export LANG=C
 
-COMMAND="$1"
-KERNEL_VERSION="$2"
+COMMAND="${1:?}"
+KERNEL_VERSION="${2:?}"
 BOOT_DIR_ABS="${3%/*}/0-rescue"
 KERNEL_IMAGE="$4"
 
-# Skip this plugin if we're using a different generator. If nothing is specified,
-# assume we're wanted since we're installed.
-if [ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" != "dracut" ]; then
+# If the initrd was provided on the kernel command line, we shouldn't generate our own.
+if [[ "$COMMAND" = "add" && "$#" -gt 4 ]]; then
+    exit 0
+fi
+
+# Do not attempt to create initramfs if the supplied image is already a UKI
+if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
+    exit 0
+fi
+
+if [[ "$KERNEL_INSTALL_UKI_GENERATOR" = "dracut" ]]; then
+    # Rescue images currently not compatible with UKIs
+    exit 0
+elif [[ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" != "dracut" ]]; then
+    # We are not the initrd generator
     exit 0
 fi
 
@@ -119,8 +131,8 @@ case "$COMMAND" in
 
         if [[ ! -f "$BOOT_DIR_ABS/$INITRD" ]]; then
             # shellcheck disable=SC2046
-            dracut -f --no-hostonly --no-uefi \
-                -a "rescue" \
+            dracut -f \
+                --add-confdir rescue \
                 $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
                 --kver "$KERNEL_VERSION" \
                 "$BOOT_DIR_ABS/$INITRD"


### PR DESCRIPTION
No need to fork rescue images generation dowsntream.

This fixes the case where KERNEL_INSTALL_IMAGE_TYPE is set to "uki"

