### PR TITLE
[F42] fix(systemd): add missing modprobe@.service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -72,6 +72,8 @@ install() {
         "$systemdsystemunitdir"/paths.target \
         "$systemdsystemunitdir"/umount.target \
         "$systemdsystemunitdir"/sys-kernel-config.mount \
+        \
+        "$systemdsystemunitdir"/modprobe@.service \
         "$systemdsystemunitdir"/systemd-halt.service \
         "$systemdsystemunitdir"/systemd-poweroff.service \
         "$systemdsystemunitdir"/systemd-reboot.service \
@@ -95,6 +97,8 @@ install() {
         inst_multiple -H -o \
             "$systemdutilconfdir"/system.conf \
             "$systemdutilconfdir"/system.conf.d/*.conf \
+            "$systemdsystemconfdir"/modprobe@.service \
+            "$systemdsystemconfdir/modprobe@.service.d/*.conf" \
             /etc/hosts \
             /etc/hostname \
             /etc/nsswitch.conf \


### PR DESCRIPTION
sys-kernel-config.mount needs modprobe@configfs.service since systemd v246.7
(https://github.com/systemd/systemd/commit/42cc2855), so the kernel configfs
fails to mount in the initrd.

(cherry picked from commit 928252a145ca44627ba5873e01245eabe246992f, conflict resolved manually)

Resolves: https://github.com/rhkdump/kdump-utils/issues/109