### PR TITLE
dracut fixes/improvements for Qualcomm Windows on Arm laptops

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -334,6 +334,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/70ppcmac
 %{dracutlibdir}/modules.d/70pcmcia
 %{dracutlibdir}/modules.d/70qemu
+%{dracutlibdir}/modules.d/70qcom-adsp
 %{dracutlibdir}/modules.d/73crypt-gpg
 %{dracutlibdir}/modules.d/73crypt-loop
 %{dracutlibdir}/modules.d/73fido2

--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -319,6 +319,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/68lvmthinpool-monitor
 %{dracutlibdir}/modules.d/70btrfs
 %{dracutlibdir}/modules.d/70crypt
+%{dracutlibdir}/modules.d/70devicetree-fw
 %{dracutlibdir}/modules.d/70dm
 %{dracutlibdir}/modules.d/70dmraid
 %{dracutlibdir}/modules.d/70kernel-modules

--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -8,7 +8,7 @@
 
 Name: dracut
 Version: 109
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 Summary: Initramfs generator using udev
 
@@ -457,6 +457,10 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{_prefix}/lib/kernel/install.d/51-dracut-rescue.install
 
 %changelog
+* Sat Mar 14 2026 Hans de Goede <johannes.goede@oss.qualcomm.com> - 109-2
+- feat(dracut): add module to add fw files from DT firmware-name properties
+- feat(dracut): add module to load Qualcomm ADSP module pre-udev
+
 * Thu Jan 22 2026 Pavel Valena <pvalena@redhat.com> - 109-1
 - Rebase to dracut-109
 

--- a/modules.d/70devicetree-fw/module-setup.sh
+++ b/modules.d/70devicetree-fw/module-setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# Devicetree based platforms may need board / model specific firmwares in
+# the initrd. E.g. Qualcomm Snapdragon Windows-on-Arm (WoA) laptops need model
+# specific firmware files in the initrd for the ADSP/Type-C controller.
+# The filenames for these firmware files are specified in "firmware-name"
+# devicetree properties, this module copies any such files to the initrd.
+
+# called by dracut
+check() {
+    local _arch=${DRACUT_ARCH:-$(uname -m)}
+    # Restrict to aarch64 for now, may be used on other archs in the future
+    [ "$_arch" = "aarch64" ] || return 1
+    if [[ $hostonly ]]; then
+        [ -d /sys/firmware/devicetree/base ] || return 1
+    else
+        # ATM install_generic only copies qcom model specific firmwares
+        [ -d /lib/firmware/qcom ] || return 1
+    fi
+    return 0
+}
+
+# hostonly install (hostonly / generic use completely different approaches)
+install_hostonly() {
+    local _fw_names=""
+    # contents of firmware-name file is 0 delimited
+    while read -r -d $'\0' fw; do
+        _fw_names="${_fw_names} $fw"
+    done < <(find /sys/firmware/devicetree/base -name firmware-name -exec cat {} \;)
+
+    local _fw_files=""
+    for i in ${_fw_names}; do
+        # add '*' after firmware-name for .gz, etc. compression
+        _fw_files="${_fw_files} /lib/firmware/$i*"
+    done
+
+    # shellcheck disable=SC2086 # globbing is wanted here
+    inst_multiple -o ${_fw_files}
+}
+
+# generic install (hostonly / generic use completely different approaches)
+install_generic() {
+    # ATM only qcom WoA laptops need this
+    for soc in qcom/sc8280xp qcom/x1e80100; do
+        # add '*' after mbn for .gz, etc. compression
+        for fw in \
+            "${dracutsysrootdir-}/lib/firmware/$soc"/*/*/*.mbn* \
+            "${dracutsysrootdir-}/lib/firmware/$soc"/*/*/*.elf*; do
+            [ -f "$fw" ] || continue
+            fw=${fw#"${dracutsysrootdir-}"}
+            inst_dir "${fw%/*}"
+            $DRACUT_CP -L -t "${initdir}${fw%/*}" "$fw"
+        done
+    done
+}
+
+# called by dracut
+install() {
+    if [[ $hostonly ]]; then
+        install_hostonly
+    else
+        install_generic
+    fi
+}

--- a/modules.d/70qcom-adsp/module-setup.sh
+++ b/modules.d/70qcom-adsp/module-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# On Qualcomm sc8280xp and x1e laptops the kernel reboots the ADSP with new
+# firmware because the BIOS loads ADSP firmware with limited functionality
+# without sound or battery charge/status reading support.
+#
+# Unfortunately the ADSP also controls the TCPM (Type-C Port Manager) and
+# rebooting the ADSP also resets the TCPM, causing any USB devices connected
+# over Type-C ports to get disconnected as all devices on the USB bus are
+# removed and re-enumerated.
+#
+# This breaks booting from USB-drives as the drive gets disconnected and
+# re-enumerated as a new block device, leaving any filesystems mounted
+# before the ADSP reset without any backing device.
+#
+# To workaround this, this module load the ADSP driver from a pre-udev hook
+# so that the USB re-enumeration happens before the rootfs is mounted.
+
+# called by dracut
+check() {
+    local _arch=${DRACUT_ARCH:-$(uname -m)}
+    [ "$_arch" = "aarch64" ] || return 1
+    if [[ $hostonly ]]; then
+        grep -q -E 'qcom,sc8280xp-adsp-pas|qcom,x1e80100-adsp-pas' \
+            /sys/bus/platform/devices/*.remoteproc/modalias 2> /dev/null || return 1
+    fi
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods qcom_q6v5_pas
+}
+
+# called by dracut
+install() {
+    inst_hook pre-udev 30 "$moddir/qcom-adsp-pre-udev.sh"
+}

--- a/modules.d/70qcom-adsp/qcom-adsp-pre-udev.sh
+++ b/modules.d/70qcom-adsp/qcom-adsp-pre-udev.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Ensure ADSP module is loaded and Type-C USB busses are reset before
+# filesystems are mounted
+
+if grep -q -E 'qcom,sc8280xp-adsp-pas|qcom,x1e80100-adsp-pas' \
+    /sys/bus/platform/devices/*.remoteproc/modalias 2> /dev/null; then
+    modprobe qcom_q6v5_pas
+fi


### PR DESCRIPTION
With https://fedoraproject.org/wiki/Changes/Automatic_DTB_selection_for_aarch64_EFI_systems it is now possible to dd Fedora 44 live ISOs to a USB drive and having booting the live distro work OOTB on Qualcomm Windows on Arm laptops, including using the new web installer to install Fedora 44 on the laptop.

But there are still various issues to resolve. Including 2 issues related to the ADSP co-processor which require dracut fixes to resolve:

1. When dracut builds a hostonly image on these laptops the qcom_q6v5_pas kernel-module gets included in the initramfs because of pinctrl supplier-links in sysfs pointing to it. But the necessary firmware does not get included in the initramfs which causes sound and battery status reporting to not work. The first patch in this PR, cherry-picked from: https://github.com/dracut-ng/dracut-ng/pull/2266 fixes this (see commit message for details).

2. Booting the ADSP causes any USB drives on Type-C ports to get disconnected and re-enumerated breaking booting from a (liveOS) USB drive on the Type-C ports. The second patch, cherry-picked from: https://github.com/dracut-ng/dracut-ng/pull/2302 works around this by loading the ADSP driver from a pre-udev hook on systems which use this driver.

Note ideally this PR (and especially its f44 branch counterpart) should be merged before the Fedora 44 final-freeze (say before March 27th) to avoid the Fedora 44 final isos suffering from these issues. Merging this even sooner would be better so that it gets more testing before the Fedora 44 final freeze. Note I do not expect this to cause any issues on other systems, but you never know.

I noticed that the dracut-fedora workflow seems to be to submit source-git PRs rather then dist-git PRs, so I'm following that practice here.